### PR TITLE
allow empty interface definition

### DIFF
--- a/eslint-config-typescript/index.js
+++ b/eslint-config-typescript/index.js
@@ -12,6 +12,9 @@ module.exports = {
   ],
   rules: {
     // core
+    "@typescript-eslint/no-empty-interface": ['warn', {
+      allowSingleExtends: true
+    }],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-expressions': ['error', {
       allowShortCircuit: false,


### PR DESCRIPTION
This disables https://typescript-eslint.io/rules/no-empty-interface/

I think this should be up to the dev. If you want to export a named interface (whether empty or single extended) for future changes, you should be able to. Additionally, this rule also complains on class/interface merging